### PR TITLE
add a Config and related methods

### DIFF
--- a/src/async.rs
+++ b/src/async.rs
@@ -23,7 +23,7 @@ use log::{debug, error, info, trace};
 use reqwest::{Client, Response, StatusCode};
 use sha2::{Digest, Sha256};
 
-use crate::{BlockStatus, BlockSummary, Builder, Error, OutputStatus, TxStatus};
+use crate::{BlockStatus, BlockSummary, Builder, Config, Error, OutputStatus, TxStatus};
 
 #[derive(Debug, Clone)]
 pub struct AsyncClient {
@@ -32,7 +32,7 @@ pub struct AsyncClient {
 }
 
 impl AsyncClient {
-    /// build an async client from a builder
+    /// build an async client from a [`Builder`]
     pub fn from_builder(builder: Builder) -> Result<Self, Error> {
         let mut client_builder = Client::builder();
 
@@ -47,6 +47,11 @@ impl AsyncClient {
         }
 
         Ok(Self::from_client(builder.base_url, client_builder.build()?))
+    }
+
+    /// build an async client from a [`Config`]
+    pub fn from_config(base_url: &str, config: Config) -> Result<Self, Error> {
+        Self::from_builder(Builder::from_config(base_url, config))
     }
 
     /// build an async client from the base url and [`Client`]

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -25,7 +25,7 @@ use sha2::{Digest, Sha256};
 
 use ureq::{Agent, Proxy, Response};
 
-use crate::{BlockStatus, BlockSummary, Builder, Error, OutputStatus, TxStatus, Utxo};
+use crate::{BlockStatus, BlockSummary, Builder, Config, Error, OutputStatus, TxStatus, Utxo};
 
 #[derive(Debug, Clone)]
 pub struct BlockingClient {
@@ -47,6 +47,11 @@ impl BlockingClient {
         }
 
         Ok(Self::from_agent(builder.base_url, agent_builder.build()))
+    }
+
+    /// build a blocking client from a [`Config`]
+    pub fn from_config(base_url: &str, config: Config) -> Result<Self, Error> {
+        Self::from_builder(Builder::from_config(base_url, config))
     }
 
     /// build a blocking client from an [`Agent`]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,32 @@ pub fn convert_fee_rate(target: usize, estimates: HashMap<String, f64>) -> Resul
 }
 
 #[derive(Debug, Clone)]
+pub struct Config {
+    /// Optional URL of the proxy to use to make requests to the Esplora server
+    ///
+    /// The string should be formatted as: `<protocol>://<user>:<password>@host:<port>`.
+    ///
+    /// Note that the format of this value and the supported protocols change slightly between the
+    /// blocking version of the client (using `ureq`) and the async version (using `reqwest`). For more
+    /// details check with the documentation of the two crates. Both of them are compiled with
+    /// the `socks` feature enabled.
+    ///
+    /// The proxy is ignored when targeting `wasm32`.
+    pub proxy: Option<String>,
+    /// Socket timeout.
+    pub timeout: Option<u64>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            proxy: None,
+            timeout: Some(30),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct Builder {
     pub base_url: String,
     /// Optional URL of the proxy to use to make requests to the Esplora server
@@ -125,6 +151,15 @@ impl Builder {
             base_url: base_url.to_string(),
             proxy: None,
             timeout: None,
+        }
+    }
+
+    /// Instantiate a builder from a URL and a config
+    pub fn from_config(base_url: &str, config: Config) -> Self {
+        Builder {
+            base_url: base_url.to_string(),
+            proxy: config.proxy,
+            timeout: config.timeout,
         }
     }
 


### PR DESCRIPTION
With this PR we make the esplora client more similar to the electrum one (see https://github.com/RGB-WG/rgb/pull/199 for a reason to have this alignment). IMO with this in place we could drop the `Builder`, which seems less practical than the `Config` approach. But @dr-orlovsky I'll remove it only if you agree with me on this.