### PR TITLE
Fix for wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ reqwest = { version = "0.12.5", optional = true, default-features = false, featu
 default = ["blocking", "async", "async-https"]
 all = ["blocking"]
 blocking = ["ureq", "ureq/socks-proxy"]
+blocking-wasm = ["ureq"]
 async = ["reqwest", "reqwest/socks"]
 async-https = ["async", "reqwest/default-tls"]
 async-https-native = ["async", "reqwest/native-tls"]

--- a/src/async.rs
+++ b/src/async.rs
@@ -63,7 +63,7 @@ impl AsyncClient {
     pub async fn tx(&self, txid: &Txid) -> Result<Option<Tx>, Error> {
         let resp = self
             .client
-            .get(&format!("{}/tx/{}/raw", self.url, txid))
+            .get(format!("{}/tx/{}/raw", self.url, txid))
             .send()
             .await;
 
@@ -103,7 +103,7 @@ impl AsyncClient {
     ) -> Result<Option<Txid>, Error> {
         let resp = self
             .client
-            .get(&format!("{}/block/{}/txid/{}", self.url, block_hash, index))
+            .get(format!("{}/block/{}/txid/{}", self.url, block_hash, index))
             .send()
             .await?;
 
@@ -118,7 +118,7 @@ impl AsyncClient {
     pub async fn tx_status(&self, txid: &Txid) -> Result<TxStatus, Error> {
         let resp = self
             .client
-            .get(&format!("{}/tx/{}/status", self.url, txid))
+            .get(format!("{}/tx/{}/status", self.url, txid))
             .send()
             .await?;
 
@@ -144,7 +144,7 @@ impl AsyncClient {
     pub async fn block_status(&self, block_hash: &BlockHash) -> Result<BlockStatus, Error> {
         let resp = self
             .client
-            .get(&format!("{}/block/{}/status", self.url, block_hash))
+            .get(format!("{}/block/{}/status", self.url, block_hash))
             .send()
             .await?;
 
@@ -207,7 +207,7 @@ impl AsyncClient {
     ) -> Result<Option<OutputStatus>, Error> {
         let resp = self
             .client
-            .get(&format!("{}/tx/{}/outspend/{}", self.url, txid, index))
+            .get(format!("{}/tx/{}/outspend/{}", self.url, txid, index))
             .send()
             .await?;
 
@@ -219,23 +219,20 @@ impl AsyncClient {
     }
 
     pub async fn broadcast(&self, tx: &Tx) -> Result<(), Error> {
-        self
-            .client
-            .post(&format!("{}/tx", self.url))
+        self.client
+            .post(format!("{}/tx", self.url))
             .body(format!("{tx:x}").to_string())
             .send()
-            .await?
-            ;
+            .await?;
 
         Ok(())
     }
-
 
     /// Get the current height of the blockchain tip
     pub async fn height(&self) -> Result<u32, Error> {
         let resp = self
             .client
-            .get(&format!("{}/blocks/tip/height", self.url))
+            .get(format!("{}/blocks/tip/height", self.url))
             .send()
             .await?;
 
@@ -246,7 +243,7 @@ impl AsyncClient {
     pub async fn tip_hash(&self) -> Result<BlockHash, Error> {
         let resp = self
             .client
-            .get(&format!("{}/blocks/tip/hash", self.url))
+            .get(format!("{}/blocks/tip/hash", self.url))
             .send()
             .await?;
 
@@ -259,7 +256,7 @@ impl AsyncClient {
     pub async fn block_hash(&self, block_height: u32) -> Result<BlockHash, Error> {
         let resp = self
             .client
-            .get(&format!("{}/block-height/{}", self.url, block_height))
+            .get(format!("{}/block-height/{}", self.url, block_height))
             .send()
             .await?;
 
@@ -305,7 +302,7 @@ impl AsyncClient {
     pub async fn fee_estimates(&self) -> Result<HashMap<String, f64>, Error> {
         Ok(self
             .client
-            .get(&format!("{}/fee-estimates", self.url,))
+            .get(format!("{}/fee-estimates", self.url,))
             .send()
             .await?
             .error_for_status()?

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -23,7 +23,9 @@ use bpstd::{BlockHash, ConsensusDecode, ScriptPubkey, Tx, Txid};
 use log::{debug, error, info, trace};
 use sha2::{Digest, Sha256};
 
-use ureq::{Agent, Proxy, Response};
+#[cfg(not(target_arch = "wasm32"))]
+use ureq::Proxy;
+use ureq::{Agent, Response};
 
 use crate::{BlockStatus, BlockSummary, Builder, Config, Error, OutputStatus, TxStatus, Utxo};
 
@@ -42,6 +44,7 @@ impl BlockingClient {
             agent_builder = agent_builder.timeout(Duration::from_secs(timeout));
         }
 
+        #[cfg(not(target_arch = "wasm32"))]
         if let Some(proxy) = &builder.proxy {
             agent_builder = agent_builder.proxy(Proxy::new(proxy)?);
         }


### PR DESCRIPTION
This PR adds a `blocking-wasm` feature that avoids importing the `socks` dependency (which doesn't compile on wasm)